### PR TITLE
chore: ErrorCode에 argument 반영 취소

### DIFF
--- a/src/main/kotlin/com/van1164/lottoissofar/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/exception/ErrorCode.kt
@@ -3,17 +3,17 @@ package com.van1164.lottoissofar.common.exception
 import org.springframework.http.HttpStatus
 
 
-enum class ErrorCode (val status:Int, val code:String, val message:String, private var expression: ((Any) -> String)? = null) {
+enum class ErrorCode (val status:Int, val code:String, val message:String) {
     // Common
     BAD_REQUEST(400, "C001", "요청 파라미터 혹은 요청 바디의 값을 다시 확인하세요."),
     INTERNAL_SERVER_ERROR(500, "C002", "Internal Server Error"),
     INVALID_INPUT_VALUE(400, "C003", "유효하지 않은 입력입니다."),
-    NOT_FOUND(404, "C004", "Not Found", {id -> "not found id : $id"}),
+    NOT_FOUND(404, "C004", "Not Found"),
     DATETIME_INVALID(400, "C005", "유효하지 않은 날짜입니다"),
     MESSAGE_SEND_FAIL(400, "C006", "메시지 전송 실패"),
 
     // Raffle
-    RAFFLE_NOT_FOUND(404, "R001", "Raffle을 찾을 수 없습니다.", {raffleId -> "래플 ID : $raffleId | Raffle을 찾을 수 없습니다."}),
+    RAFFLE_NOT_FOUND(404, "R001", "Raffle을 찾을 수 없습니다."),
     RAFFLE_ALREADY_INACTIVE(409, "R002", "이미 완료된 Raffle입니다. 새로운 Raffle에 참가해주세요."),
     RAFFLE_MAX_CAPACITY_REACHED(409, "R003", "필요한 인원이 모두 채워져 Raffle 참여가 마감되었습니다. 새로운 Raffle에 참가해주세요."),
     RAFFLE_PURCHASE_LOCK_TIMEOUT(408, "R004", "Raffle 결제 과정에서 시간 초과가 발생했습니다."),
@@ -32,20 +32,6 @@ enum class ErrorCode (val status:Int, val code:String, val message:String, priva
     SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다."),
 
     // User
-    USER_TICKET_LOCK_TIMEOUT(408, "U001", "사용자 응모권 추가에 실패했습니다.", {userId -> "사용자 ID : $userId | 응모권 추가에 실패하였습니다."});
+    USER_TICKET_LOCK_TIMEOUT(408, "U001", "사용자 응모권 추가에 실패했습니다.");
 
-    private var messageArgument: Any? = null
-
-    fun setMessageWith(arg: Any?): ErrorCode {
-        this.messageArgument = arg
-        return this
-    }
-
-    fun getFormattedMessage(): String {
-        return if (expression != null && messageArgument != null) {
-            expression!!.invoke(messageArgument!!)
-        } else {
-            message
-        }
-    }
 }

--- a/src/main/kotlin/com/van1164/lottoissofar/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/exception/GlobalExceptionHandler.kt
@@ -55,7 +55,7 @@ class GlobalExceptionHandler(
         e: GlobalExceptions.NotFoundException
     ) : ErrorResponse{
         return ErrorResponse(
-            message = e.errorCode.getFormattedMessage(),
+            message = e.errorCode.message,
             description = e.message
         )
     }
@@ -66,7 +66,7 @@ class GlobalExceptionHandler(
         e: GlobalExceptions.InternalErrorException
     ) : ErrorResponse{
         return ErrorResponse(
-            message = e.errorCode.getFormattedMessage(),
+            message = e.errorCode.message,
             description = e.message
         )
     }

--- a/src/main/kotlin/com/van1164/lottoissofar/item/service/ItemService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/item/service/ItemService.kt
@@ -37,7 +37,7 @@ class ItemService(
     }
 
     @Transactional
-    fun stop(id: Long) : ResponseEntity<Any> {
+    fun stop(id: Long): ResponseEntity<Any> {
         val item = findById(id)
         item.possibleRaffle = false
         return ResponseEntity.ok().build()
@@ -52,15 +52,18 @@ class ItemService(
     }
 
     fun findById(id: Long): Item {
-        return itemJpaRepository.findById(id).orElseThrow { GlobalExceptions.NotFoundException(
-            NOT_FOUND.setMessageWith(id)) }
+        return itemJpaRepository.findById(id).orElseThrow {
+            GlobalExceptions.NotFoundException(
+                NOT_FOUND
+            )
+        }
     }
 
     @Transactional
     fun createDescriptionImage(itemId: Long, image: MultipartFile): ResponseEntity<Any> {
         val item = findById(itemId)
-        val imageUrl =  s3Component.imageUpload(image)
-        val itemImage = ItemDescriptionImage(imageUrl,item)
+        val imageUrl = s3Component.imageUpload(image)
+        val itemImage = ItemDescriptionImage(imageUrl, item)
         item.imageList.add(itemImage)
         return ResponseEntity.ok().body(itemImage)
     }

--- a/src/main/kotlin/com/van1164/lottoissofar/raffle/exception/RaffleExceptionHandler.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/raffle/exception/RaffleExceptionHandler.kt
@@ -14,7 +14,7 @@ class RaffleExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun alreadyFinishedExceptionHandle(e : RaffleExceptions.RaffleException): ErrorResponse {
         return ErrorResponse(
-            message = e.errorCode.getFormattedMessage(),
+            message = e.errorCode.message,
             description = e.message
         )
     }
@@ -23,7 +23,7 @@ class RaffleExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun raffleExceptionHandle(e : RaffleExceptions.RaffleException): ErrorResponse {
         return ErrorResponse(
-            message = e.errorCode.getFormattedMessage(),
+            message = e.errorCode.message,
             description = e.message
         )
     }

--- a/src/main/kotlin/com/van1164/lottoissofar/raffle/service/RaffleService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/raffle/service/RaffleService.kt
@@ -59,7 +59,7 @@ class RaffleService(
         user: User
     ): ResponseEntity<PurchaseHistory> {
         val raffle = raffleRepository.findById(raffleId)
-            .orElseThrow { GlobalExceptions.NotFoundException(RAFFLE_NOT_FOUND.setMessageWith(raffleId)) }
+            .orElseThrow { GlobalExceptions.NotFoundException(RAFFLE_NOT_FOUND) }
         validateRaffleStatus(raffle, RAFFLE_ALREADY_INACTIVE)
         validateTicketCount(raffle, RAFFLE_MAX_CAPACITY_REACHED)
 

--- a/src/main/kotlin/com/van1164/lottoissofar/user/service/UserService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/user/service/UserService.kt
@@ -38,14 +38,17 @@ class UserService(
 
     fun findByUserId(userId: String): User {
         return userRepository.findUserByUserId(userId)
-            ?: run { throw GlobalExceptions.NotFoundException(NOT_FOUND.setMessageWith(userId)) };
+            ?: run {
+                println("not found loginId : $userId")
+                throw GlobalExceptions.NotFoundException(NOT_FOUND)
+            };
     }
 
     @Transactional
     fun saveTestUser(): String {
         val user = User(
             "testUser" + UUID.randomUUID().toString(),
-            "testEmaiil" + UUID.randomUUID().toString(),
+            "testEmail" + UUID.randomUUID().toString(),
             UUID.randomUUID().toString()
         )
         userRepository.save(user)
@@ -61,7 +64,8 @@ class UserService(
                 userRepository.save(user)
                 return user.tickets
             } else {
-                throw GlobalExceptions.InternalErrorException(USER_TICKET_LOCK_TIMEOUT.setMessageWith(user.userId))
+                println("사용자 ID: ${user.userId} | 응모권 추가에 실패하였습니다.")
+                throw GlobalExceptions.InternalErrorException(USER_TICKET_LOCK_TIMEOUT)
             }
         } finally {
             if (userLock.isHeldByCurrentThread) {


### PR DESCRIPTION
서두와 결론으로 정리가 되지만 혹 참고가 필요하시면
`고려한 요소` 챕터를 검토해보실 수 있을 것 같습니다. 👍

## 서두
* function type을 이용한 argument 반영을 취소하기로 했습니다.

* 이후 계획으로 다음 단계를 통해 리팩토링하기로 했습니다
  1. 이전과 같이 sout으로 기록
  2. 스프링 AOP 학습
  3. 로그 라이브러리 학습
  4. 이후 최적화 시도

## 고려한 요소
### Q1.  Enum 하나에 2개 이상의 변형된 문장을 허용하는 건 어떨까?
* Enum 자체의 학습 비용이 지나치게 올라가는 것 같아 제외했습니다.

### Q2. Enum 하나에 한 가지의 변형된 문장만을 허용하는, 현재의 설계는 괜찮을까?
* 보다 구체적인 메시지를 나타내는 거라면 괜찮을 것 같았습니다.
* 그러나 AOP 사용으로 argument가 Exception이 throw되기 전에
 log로 기록돼 있다면 메시지가 중복될 수 있다고 생각했습니다.

### Q3. 여러 개의 argument를 expression에 대입할 방법은?
* `setMessageWith` 메서드에 가변인자 parameter를 설정하고 
Enum primary 생성자에는 `(Array<out Any>) -> String)?` 를 두는 방법을 생각했는데
두 가지 문제점이 있었습니다.

  - 하나는  `setMessageWith` argument 의 순서가 학습 비용이 된다는 점이고
  - 두 번째는 `Array<out Any>?` 멤버 필드를 쓰기 때문에 
Enum의 선언부에서 이전과 같이 직관적인 변수명을 사용할 수 없었습니다.  대신 
![image](https://github.com/user-attachments/assets/7f8c5ddb-7fea-4550-a886-93d8e95d99d1)
상기한 것처럼 배열 인덱스를 순차적으로 기록하게 됐습니다. 
개수가 많아질수록 바로 알아보기 어려울 거라  판단했습니다.

### Q4. 3번 주제의 개선안은?
* 기본값이 null인 멤버 필드 여럿과 메서드 체이닝으로 이를 극복할 수 있다고 봤습니다.
builder 패턴처럼 메서드명을 key로 하고 
체이닝된 메서드의 argument를 value로 한다면 앞서 언급한 문제들을 해결할 수 있다고 생각했습니다.
  - 그러나 이 방법도 문제점이 있었습니다.
  1. 여러 메시지에 대응할 수 있도록 표현 범위를 한정하고 추상화된 단어로 메서드명을 선정해야 하는데 이 공수도 크고
  2. 이렇게 완성한 클래스 정의가 다시 학습 비용이 됩니다.

## 결론

서두에서 언급한 계획에 부연 설명을 하면 다음과 같습니다. 
  1. 이전과 같이 sout으로 기록
    - 당장의 수요를 해결할 수 있는 동시에 리팩토링 포인트를 검색 가능하게 남기는 효과가 있다고 봤습니다.
  2. 스프링 AOP 학습
  3. 로그 라이브러리 학습
    - 로그로 먼저 이른 최적화를 해버리면 검색 경로가 사라져 2, 3의 순서로 학습할 필요가 있다고 봤습니다.
  4. 이후 최적화 시도

계획대로는 오래 진행되는 issue가 될 텐데
이렇게 한다면 프로젝트 마일스톤에 어긋나지 않게 
다른 이슈와 같이 파이프라이닝 하려고 합니다.

이번 PR은 이상입니다.