### PR TITLE
refactor: 사용자 당첨내역 조회 페이징 초안

### DIFF
--- a/src/main/kotlin/com/van1164/lottoissofar/common/dto/winner_history/ReadWinnerHistoryDto.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/dto/winner_history/ReadWinnerHistoryDto.kt
@@ -1,0 +1,9 @@
+package com.van1164.lottoissofar.common.dto.winner_history
+
+data class ReadWinnerHistoryDto (
+    val id: Long,
+    val userId: String,
+    val reviewTitle: String,
+    val reviewDescription: String,
+    val reviewImageUrl: String
+)

--- a/src/main/kotlin/com/van1164/lottoissofar/common/dto/winner_history/response/ReadWinnerHistoryResponse.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/dto/winner_history/response/ReadWinnerHistoryResponse.kt
@@ -1,0 +1,21 @@
+package com.van1164.lottoissofar.common.dto.winner_history.response
+
+import com.van1164.lottoissofar.common.dto.winner_history.ReadWinnerHistoryDto
+
+data class ReadWinnerHistoryResponse (
+    val id: Long,
+    val reviewTitle: String,
+    val reviewDescription: String,
+    val reviewImageUrl: String
+) {
+    companion object {
+        fun of(dto: ReadWinnerHistoryDto): ReadWinnerHistoryResponse {
+            return ReadWinnerHistoryResponse(
+                id = dto.id,
+                reviewTitle = dto.reviewTitle,
+                reviewDescription = dto.reviewDescription,
+                reviewImageUrl = dto.reviewImageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/winner_history/controller/WinnerHistoryController.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/winner_history/controller/WinnerHistoryController.kt
@@ -1,0 +1,26 @@
+package com.van1164.lottoissofar.winner_history.controller
+
+import com.van1164.lottoissofar.common.domain.User
+import com.van1164.lottoissofar.common.dto.winner_history.response.ReadWinnerHistoryResponse
+import com.van1164.lottoissofar.common.response.CursorPage
+import com.van1164.lottoissofar.winner_history.service.WinnerHistoryService
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class WinnerHistoryController(
+    private val winnerHistoryService: WinnerHistoryService
+) {
+    @GetMapping("winner_history")
+    fun findByUserId(
+        @Parameter(hidden = true) user: User,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(required = false, defaultValue = "5") size: Int
+    ): CursorPage<ReadWinnerHistoryResponse> {
+        return winnerHistoryService.findByUserId(user.userId, cursor, size)
+    }
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepository.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepository.kt
@@ -3,6 +3,5 @@ package com.van1164.lottoissofar.winner_history.repository
 import com.van1164.lottoissofar.common.domain.WinnerHistory
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface WinnerHistoryRepository : JpaRepository<WinnerHistory, Long> {
-    fun findByUserId(userId: String): List<WinnerHistory>
+interface WinnerHistoryRepository : JpaRepository<WinnerHistory, Long>, WinnerHistoryRepositoryCustom {
 }

--- a/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepositoryCustom.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.van1164.lottoissofar.winner_history.repository
+
+import com.van1164.lottoissofar.common.dto.winner_history.ReadWinnerHistoryDto
+import org.springframework.data.domain.Page
+
+interface WinnerHistoryRepositoryCustom {
+    fun findByUserId(userId: String, cursor: Long?, size: Int): Page<ReadWinnerHistoryDto>
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/winner_history/repository/WinnerHistoryRepositoryImpl.kt
@@ -1,0 +1,56 @@
+package com.van1164.lottoissofar.winner_history.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.van1164.lottoissofar.common.domain.QReview
+import com.van1164.lottoissofar.common.domain.QReview.*
+import com.van1164.lottoissofar.common.domain.QWinnerHistory
+import com.van1164.lottoissofar.common.domain.QWinnerHistory.*
+import com.van1164.lottoissofar.common.domain.WinnerHistory
+import com.van1164.lottoissofar.common.dto.winner_history.ReadWinnerHistoryDto
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.support.PageableExecutionUtils
+
+class WinnerHistoryRepositoryImpl (
+    em : EntityManager
+) : WinnerHistoryRepositoryCustom {
+    private val query = JPAQueryFactory(em)
+    override fun findByUserId(userId: String, cursor: Long?, size: Int): Page<ReadWinnerHistoryDto> {
+        val list = query
+            .select(
+                Projections
+                    .constructor(
+                        ReadWinnerHistoryDto::class.java,
+                        winnerHistory.id,
+                        winnerHistory.userId,
+                        winnerHistory.review.title,
+                        winnerHistory.review.description,
+                        winnerHistory.review.imageUrl
+                    )
+            )
+            .from(winnerHistory)
+            .where(
+                winnerHistory.userId.eq(userId),
+                winnerHistory.id.lt(cursor)
+            )
+            .innerJoin(winnerHistory.review, review)
+            .orderBy(winnerHistory.id.desc())
+            .limit(size.toLong())
+            .fetch()
+
+        val countQuery = {
+            query
+                .select(winnerHistory.count())
+                .from(winnerHistory)
+                .where(
+                    winnerHistory.userId.eq(userId),
+                    winnerHistory.id.lt(cursor)
+                )
+                .fetchOne()?: 0L
+        }
+
+        return PageableExecutionUtils.getPage(list, PageRequest.ofSize(size), countQuery)
+    }
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/winner_history/service/WinnerHistoryService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/winner_history/service/WinnerHistoryService.kt
@@ -2,21 +2,32 @@ package com.van1164.lottoissofar.winner_history.service
 
 import com.van1164.lottoissofar.common.domain.WinnerHistory
 import com.van1164.lottoissofar.common.domain.WinnerHistoryStatus
+import com.van1164.lottoissofar.common.dto.winner_history.response.ReadWinnerHistoryResponse
 import com.van1164.lottoissofar.common.exception.ErrorCode
 import com.van1164.lottoissofar.common.exception.GlobalExceptions
+import com.van1164.lottoissofar.common.response.CursorPage
 import com.van1164.lottoissofar.winner_history.repository.WinnerHistoryRepository
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.stream.Collectors
 
 
 @Service
 class WinnerHistoryService(
     val winnerHistoryRepository: WinnerHistoryRepository
 ) {
+    fun findByUserId(
+        userId: String,
+        cursor: Long?,
+        size: Int
+    ): CursorPage<ReadWinnerHistoryResponse> {
+        val effectiveCursor = cursor ?: Long.MAX_VALUE
+        val result = winnerHistoryRepository.findByUserId(userId, effectiveCursor, size)
+            .map { ReadWinnerHistoryResponse.of(it) }
+        val nextCursor = result.content.lastOrNull()?.id
 
-    fun findByUserId(userId: String): List<WinnerHistory> {
-        return winnerHistoryRepository.findByUserId(userId)
+        return CursorPage(result.content, nextCursor, result.hasNext())
     }
 
     @Transactional
@@ -31,7 +42,8 @@ class WinnerHistoryService(
     }
 
     fun findById(historyId: Long): WinnerHistory {
-        return winnerHistoryRepository.findById(historyId).orElseThrow { GlobalExceptions.NotFoundException(ErrorCode.NOT_FOUND) }
+        return winnerHistoryRepository.findById(historyId)
+            .orElseThrow { GlobalExceptions.NotFoundException(ErrorCode.NOT_FOUND) }
     }
 
 }


### PR DESCRIPTION
아직 테스트는 작성하지 않은 채 발생 쿼리만 확인했습니다.

![image](https://github.com/user-attachments/assets/0dfdc763-4937-4232-bff1-391eeb595404)

* 커서 기반 페이징으로 개발하고 경과를 보는 것으로 결정했습니다.
* DTO의 역할을 중첩하는 대신 
프로젝션용 DTO와 response DTO를 분리했습니다.
변환 책임은 response DTO가 가지도록 했습니다.
* 서비스 계층에서 CursorPage 반환 객체를 조성하도록 했습니다.