### PR TITLE
feat: 티켓 히스토리 그래프 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ k6-v0.51.0-macos-amd64/
 src/main/resources/allyouraffle-f271f-firebase-adminsdk-4nzuk-d1e14643e2.json
 
 src/main/resources/allyouraffleFirebaseKey.json
+
+src/main/resources/application.properties
+src/main/resources/spring-profile

--- a/src/main/kotlin/com/van1164/lottoissofar/common/dto/ticket/TicketHistoryGraphRequirementsDto.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/dto/ticket/TicketHistoryGraphRequirementsDto.kt
@@ -1,0 +1,18 @@
+package com.van1164.lottoissofar.common.dto.ticket
+
+import com.van1164.lottoissofar.common.domain.TicketHistory
+import java.time.LocalDateTime
+
+data class TicketHistoryGraphRequirementsDto (
+    val id: Long,
+    val userId: String,
+    val ticketCount: Int,
+    val createdDate: LocalDateTime?
+) {
+    constructor(ticketHistory: TicketHistory) : this (
+        id = ticketHistory.id,
+        userId = ticketHistory.userId,
+        ticketCount = ticketHistory.ticketCount,
+        createdDate = ticketHistory.createdDate
+    )
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/common/dto/ticket/response/TicketHistoryGraphResponse.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/common/dto/ticket/response/TicketHistoryGraphResponse.kt
@@ -1,0 +1,8 @@
+package com.van1164.lottoissofar.common.dto.ticket.response
+
+data class TicketHistoryGraphResponse<T> (
+    val data: List<T>,
+    val rawIntervalAverage: Long,
+    val nextCursor: Long?,
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/controller/TicketController.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/controller/TicketController.kt
@@ -1,12 +1,11 @@
 package com.van1164.lottoissofar.ticket.controller
 
 import com.van1164.lottoissofar.common.domain.TicketHistory
+import com.van1164.lottoissofar.common.response.CursorPage
 import com.van1164.lottoissofar.ticket.service.TicketService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import sun.security.krb5.internal.Ticket
+import java.time.LocalDate
 
 
 @RestController
@@ -18,5 +17,17 @@ class TicketController(
     @GetMapping("/last_1h/{userId}")
     fun getTicketsLast1h(@PathVariable userId: String): List<TicketHistory> {
         return ticketService.getTicketsLast1h(userId)
+    }
+
+    @GetMapping("/interval-deviation/{userId}")
+    fun getIntervalDeviation(
+        @PathVariable userId: String,
+        @RequestParam(required = false) endDate: LocalDate?,
+        @RequestParam(required = false) cursor: Long?,
+        @RequestParam(required = false, defaultValue = "10") size: Int
+    ): CursorPage<Double> {
+        val effectiveCursor = cursor ?: Long.MAX_VALUE
+
+        return ticketService.getDeviationPage(userId, endDate, effectiveCursor, size)
     }
 }

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/controller/TicketController.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/controller/TicketController.kt
@@ -1,6 +1,7 @@
 package com.van1164.lottoissofar.ticket.controller
 
 import com.van1164.lottoissofar.common.domain.TicketHistory
+import com.van1164.lottoissofar.common.dto.ticket.response.TicketHistoryGraphResponse
 import com.van1164.lottoissofar.common.response.CursorPage
 import com.van1164.lottoissofar.ticket.service.TicketService
 import org.springframework.web.bind.annotation.*
@@ -25,7 +26,7 @@ class TicketController(
         @RequestParam(required = false) endDate: LocalDate?,
         @RequestParam(required = false) cursor: Long?,
         @RequestParam(required = false, defaultValue = "10") size: Int
-    ): CursorPage<Double> {
+    ): TicketHistoryGraphResponse<TicketService.DensityPoint> {
         val effectiveCursor = cursor ?: Long.MAX_VALUE
 
         return ticketService.getDeviationPage(userId, endDate, effectiveCursor, size)

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepository.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
-interface TicketHistoryRepository : JpaRepository<TicketHistory, Long> {
+interface TicketHistoryRepository : JpaRepository<TicketHistory, Long>, TicketHistoryRepositoryCustom {
     fun findAllByUserIdOrderByCreatedDateDesc(userId: String): List<TicketHistory>
     fun findAllByUserIdAndCreatedDateAfter(userId: String, findTime:LocalDateTime ): List<TicketHistory>
 }

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepositoryCustom.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package com.van1164.lottoissofar.ticket.repository
+
+import com.van1164.lottoissofar.common.dto.ticket.TicketHistoryGraphRequirementsDto
+import org.springframework.data.domain.Page
+import java.time.LocalDate
+
+interface TicketHistoryRepositoryCustom {
+    fun findTicketHistoryGraph(userId: String, endDate: LocalDate?, cursor:Long, size:Int): Page<TicketHistoryGraphRequirementsDto>
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/repository/TicketHistoryRepositoryImpl.kt
@@ -1,0 +1,50 @@
+package com.van1164.lottoissofar.ticket.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.van1164.lottoissofar.common.domain.QTicketHistory.ticketHistory
+import com.van1164.lottoissofar.common.dto.ticket.TicketHistoryGraphRequirementsDto
+import jakarta.persistence.EntityManager
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.support.PageableExecutionUtils
+import java.time.LocalDate
+
+class TicketHistoryRepositoryImpl (
+    em: EntityManager
+) : TicketHistoryRepositoryCustom {
+    private val query = JPAQueryFactory(em)
+    override fun findTicketHistoryGraph(userId: String, endDate: LocalDate?, cursor: Long, size: Int): Page<TicketHistoryGraphRequirementsDto> {
+        val list = query
+            .select(
+                Projections
+                    .constructor(
+                        TicketHistoryGraphRequirementsDto::class.java,
+                        ticketHistory
+                    )
+            )
+            .from(ticketHistory)
+            .where(
+                ticketHistory.userId.eq(userId),
+                endDate?.let { ticketHistory.createdDate.before(it.plusDays(1L).atStartOfDay()) },
+                ticketHistory.id.lt(cursor)
+            )
+            .orderBy(ticketHistory.id.desc())
+            .limit(size.toLong())
+            .fetch()
+
+        val countQuery = {
+            query
+                .select(ticketHistory.count())
+                .from(ticketHistory)
+                .where(
+                    ticketHistory.userId.eq(userId),
+                    endDate?.let { ticketHistory.createdDate.before(it.plusDays(1L).atStartOfDay()) },
+                    ticketHistory.id.lt(cursor)
+                )
+                .fetchOne()?: 0L
+        }
+
+        return PageableExecutionUtils.getPage(list, PageRequest.ofSize(size), countQuery)
+    }
+}

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/service/TicketService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/service/TicketService.kt
@@ -1,11 +1,18 @@
 package com.van1164.lottoissofar.ticket.service
 
 import com.van1164.lottoissofar.common.domain.TicketHistory
+import com.van1164.lottoissofar.common.exception.ErrorCode.INTERNAL_SERVER_ERROR
+import com.van1164.lottoissofar.common.exception.GlobalExceptions
+import com.van1164.lottoissofar.common.response.CursorPage
 import com.van1164.lottoissofar.ticket.repository.TicketHistoryRepository
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
-import sun.security.krb5.internal.Ticket
+import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.math.log10
 
 
 @Service
@@ -19,5 +26,28 @@ class TicketService(
 
     fun getTicketsLast1h(userId: String): List<TicketHistory> {
         return ticketHistoryRepository.findAllByUserIdAndCreatedDateAfter(userId, LocalDateTime.now().minusHours(1))
+    }
+
+    fun getDeviationPage(userId: String, endDate: LocalDate?, cursor: Long, size: Int): CursorPage<Double> {
+        val result = ticketHistoryRepository.findTicketHistoryGraph(userId, endDate, cursor, size)
+        val logScaledIntervalList = result.content.zipWithNext {
+            previous, current ->
+            val durationMills = Duration.between(current.createdDate, previous.createdDate).toMillis()
+            log10(durationMills.toDouble() + 1)
+        }.sorted()
+
+        if (logScaledIntervalList.size < 4) throw GlobalExceptions.InternalErrorException(
+            INTERNAL_SERVER_ERROR
+        )
+        val q3Index = ((logScaledIntervalList.size - 1) * 3 / 4)
+        val q1Index = ((logScaledIntervalList.size - 1) / 4)
+        val sampledAverage = logScaledIntervalList.subList(q1Index, q3Index).average()
+        val deviationFromAverage = logScaledIntervalList.map { it - sampledAverage }
+
+        return CursorPage(
+            data = deviationFromAverage,
+            nextCursor = result.lastOrNull()?.id,
+            hasNext = result.totalElements - size - 2 > 0
+        )
     }
 }

--- a/src/main/kotlin/com/van1164/lottoissofar/ticket/service/TicketService.kt
+++ b/src/main/kotlin/com/van1164/lottoissofar/ticket/service/TicketService.kt
@@ -1,18 +1,17 @@
 package com.van1164.lottoissofar.ticket.service
 
 import com.van1164.lottoissofar.common.domain.TicketHistory
+import com.van1164.lottoissofar.common.dto.ticket.response.TicketHistoryGraphResponse
 import com.van1164.lottoissofar.common.exception.ErrorCode.INTERNAL_SERVER_ERROR
 import com.van1164.lottoissofar.common.exception.GlobalExceptions
 import com.van1164.lottoissofar.common.response.CursorPage
 import com.van1164.lottoissofar.ticket.repository.TicketHistoryRepository
 import jakarta.transaction.Transactional
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
-import kotlin.math.log10
+import kotlin.math.*
 
 
 @Service
@@ -28,9 +27,9 @@ class TicketService(
         return ticketHistoryRepository.findAllByUserIdAndCreatedDateAfter(userId, LocalDateTime.now().minusHours(1))
     }
 
-    fun getDeviationPage(userId: String, endDate: LocalDate?, cursor: Long, size: Int): CursorPage<Double> {
-        val result = ticketHistoryRepository.findTicketHistoryGraph(userId, endDate, cursor, size)
-        val logScaledIntervalList = result.content.zipWithNext {
+    fun getDeviationPage(userId: String, endDate: LocalDate?, cursor: Long, size: Int): TicketHistoryGraphResponse<DensityPoint> {
+        val rawList = ticketHistoryRepository.findTicketHistoryGraph(userId, endDate, cursor, size)
+        val logScaledIntervalList = rawList.content.zipWithNext {
             previous, current ->
             val durationMills = Duration.between(current.createdDate, previous.createdDate).toMillis()
             log10(durationMills.toDouble() + 1)
@@ -41,13 +40,32 @@ class TicketService(
         )
         val q3Index = ((logScaledIntervalList.size - 1) * 3 / 4)
         val q1Index = ((logScaledIntervalList.size - 1) / 4)
-        val sampledAverage = logScaledIntervalList.subList(q1Index, q3Index).average()
-        val deviationFromAverage = logScaledIntervalList.map { it - sampledAverage }
+        val sampledList = logScaledIntervalList.subList(q1Index, q3Index)
 
-        return CursorPage(
-            data = deviationFromAverage,
-            nextCursor = result.lastOrNull()?.id,
-            hasNext = result.totalElements - size - 2 > 0
+        val mean = sampledList.average()
+        val standardDeviation = sampledList.map { it - mean }.map { it * it }.average().let { sqrt(it) }
+        val deviation = logScaledIntervalList.map { it - mean }
+        val bandwidth = 1.06 * standardDeviation * logScaledIntervalList.size.toDouble().pow(-0.2)
+        val densityList = kernelDensityEstimation(deviation, bandwidth)
+
+        return TicketHistoryGraphResponse(
+            data = densityList,
+            rawIntervalAverage = (10.0.pow(mean) - 1).toLong() / 1000,
+            nextCursor = rawList.lastOrNull()?.id,
+            hasNext = rawList.totalElements - size - 2 > 0
         )
     }
+
+    private fun kernelDensityEstimation(data: List<Double>, bandwidth: Double): List<DensityPoint> {
+        // 가우시안 커널을 적용하여 각 지점에 대한 밀도 계산
+        return data.map { x ->
+            val density = data.sumOf { xi ->
+                val exponent = -0.5 * ((x - xi) / bandwidth).pow(2)
+                exp(exponent) / (bandwidth * sqrt(2 * PI))
+            } / data.size
+            DensityPoint(x, density)
+        }
+    }
+
+    data class DensityPoint(val deviation: Double, val density: Double)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.application.name=lotto-is-so-far
-spring.profiles.active=dev


### PR DESCRIPTION
티켓 히스토리 그래프 쿼리를 작성했습니다.
화폐의 비정상적인 획득을 직접 검사할 때 쓸 수 있습니다.
시퀀스는 다음과 같습니다.

1. 티켓 히스토리의 목록을 데이터베이스에서 내림차순으로 가져옵니다.
  최신 경향부터 검사하기 위하여 그렇게 설정했습니다.
```kotlin
interface TicketHistoryRepositoryCustom {
    fun findTicketHistoryGraph(userId: String, endDate: LocalDate?, cursor:Long, size:Int): Page<TicketHistoryGraphRequirementsDto>
}
```

2. 서비스 계층에서 단계적으로 가공합니다.
  * 히스토리 간의 획득 간격을 구합니다.
  * 이를 로그 스케일로 변환합니다.
  * 변환된 리스트를 이용하여, `사분범위(interquartile range) 에서의 평균`을 구합니다.
    - `하루가 지나 획득했거나 했을 경우` 처럼 이상치가 평균에 반영되는 것을 제외하고자 했습니다.
  * 리스트 요소에서 평균을 감산하여, 편차를 구합니다.
  * 편차 리스트로부터 표준편차를 구합니다. 이 표준편차를 이용하여 `커널 함수의 bandwidth`를 구합니다.
  * 커널 밀도 추정을 통해 각 요소의 확률 밀도를 구합니다.
  
 메서드의 결과로 `획득 간격들이 평균을 기준으로 얼만큼 흩어져있는지` 나타내는 `산포도 그래프`를 그릴 수 있습니다.

```kotlin
    fun getDeviationPage(userId: String, endDate: LocalDate?, cursor: Long, size: Int): TicketHistoryGraphResponse<DensityPoint> {
        val rawList = ticketHistoryRepository.findTicketHistoryGraph(userId, endDate, cursor, size)
        val logScaledIntervalList = rawList.content.zipWithNext {
            previous, current ->
            val durationMills = Duration.between(current.createdDate, previous.createdDate).toMillis()
            log10(durationMills.toDouble() + 1)
        }.sorted()

        if (logScaledIntervalList.size < 4) throw GlobalExceptions.InternalErrorException(
            INTERNAL_SERVER_ERROR
        )
        val q3Index = ((logScaledIntervalList.size - 1) * 3 / 4)
        val q1Index = ((logScaledIntervalList.size - 1) / 4)
        val sampledList = logScaledIntervalList.subList(q1Index, q3Index)

        val mean = sampledList.average()
        val standardDeviation = sampledList.map { it - mean }.map { it * it }.average().let { sqrt(it) }
        val deviation = logScaledIntervalList.map { it - mean }
        val bandwidth = 1.06 * standardDeviation * logScaledIntervalList.size.toDouble().pow(-0.2)
        val densityList = kernelDensityEstimation(deviation, bandwidth)

        return TicketHistoryGraphResponse(
            data = densityList,
            rawIntervalAverage = (10.0.pow(mean) - 1).toLong() / 1000,
            nextCursor = rawList.lastOrNull()?.id,
            hasNext = rawList.totalElements - size - 2 > 0
        )
    }
```

사용 방법은 유저 A, B를 대상으로 해당 메서드를 1회씩,
총 2회 호출하여 티켓 획득 산포도를 대조해보는 것을 생각했습니다.

참고자료:
[커널 밀도 추정에 대한 이해](https://darkpgmr.tistory.com/147)
[커널 밀도 추정](https://sungkee-book.tistory.com/2)